### PR TITLE
Add HiCache++ (No Single Basis Wins) to the Caching list

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@
 |2025.06| 🔥🔥[**DBCache**] DBCache: Dual Block Caching for Diffusion Transformers(@DefTruth, @vipshop, etc) | [[docs]](https://github.com/vipshop/cache-dit) | [[cache-dit]](https://github.com/vipshop/cache-dit) ![](https://img.shields.io/github/stars/vipshop/cache-dit.svg?style=social)|⭐️⭐️ |
 |2025.06| 🔥🔥[**DBPrune**] DBPrune: Dynamic Block Prune with Residual Caching(@DefTruth, @vipshop, etc) | [[docs]](https://github.com/vipshop/cache-dit) | [[cache-dit]](https://github.com/vipshop/cache-dit) ![](https://img.shields.io/github/stars/vipshop/cache-dit.svg?style=social)|⭐️⭐️ |
 |2025.06| 🔥🔥[**BACache**] Block-wise Adaptive Caching for Accelerating Diffusion Policy(@THU) | [[pdf]](https://arxiv.org/pdf/2506.13456) | ⚠️|⭐️⭐️ |  
+|2026.06|🔥🔥[**HiCache++**] No Single Basis Wins: A Cross-Family Study of Diffusion Feature Forecasting and the Limits of Training-Free Basis Selection(@SNU)|[[pdf]](https://doi.org/10.31224/7309) | [[hicache-plus-plus]](https://github.com/Archerkattri/hicache-plus-plus)| |
 
 ## 📙 Parallelism
 


### PR DESCRIPTION
Adds **HiCache++** to the Caching section. Paper (engrXiv): https://doi.org/10.31224/7309 — a cross-family study of diffusion feature forecasting (exponential/DMD-Prony vs polynomial/Hermite bases) with a training-free `backend="auto"` selector; the honest finding is that no single basis wins across DiT-class denoising vs flow-matching families. Code (MIT): https://github.com/Archerkattri/hicache-plus-plus (`pip install hicache-pp`). I left the Recom rating blank for you to set.