### PR TITLE
Add SparsePR to attention inference methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@
 |2025.03|🔥🔥[**SpargeAttention**] SpargeAttn: Accurate Sparse Attention Accelerating Any Model Inference(@thu-ml)|[[pdf]](https://arxiv.org/pdf/2502.18137)|[[SpargeAttn]](https://github.com/thu-ml/SpargeAttn) ![](https://img.shields.io/github/stars/thu-ml/SpargeAttn) | ⭐️⭐️ |
 |2025.05|🔥🔥[**SageAttention-3**] SageAttention3: Microscaling FP4 Attention for Inference and An Exploration of 8-bit Training(@thu-ml)|[[pdf]](https://arxiv.org/pdf/2505.11594)|[[SageAttention]](https://github.com/thu-ml/SageAttention) ![](https://img.shields.io/github/stars/thu-ml/SageAttention) | ⭐️⭐️ |
 |2025.05| 🔥🔥[**DraftAttention**] DraftAttention: Fast Video Diffusion via Low-Resolution Attention Guidance(@Northeastern University) | [[pdf]](https://arxiv.org/pdf/2505.14708)|[[draft-attention]](https://github.com/shawnricecake/draft-attention) ![](https://img.shields.io/github/stars/shawnricecake/draft-attention) | ⭐️⭐️ |
+|2026.08|🔥🔥[**SparsePR**] Partition the Support, Reconstruct the Residual: Training-Free Sparse Attention for Video Generation and World Models(@Pardis Taghavi et al.)|[[pdf]](https://arxiv.org/pdf/2608.18484)|[[SparsePR]](https://github.com/PardisTaghavi/SparsePR) ![](https://img.shields.io/github/stars/PardisTaghavi/SparsePR) | ⭐️⭐️ |
 
 
 ## ©️License  


### PR DESCRIPTION
Adds [SparsePR](https://arxiv.org/abs/2608.18484) and its [reference implementation](https://github.com/PardisTaghavi/SparsePR) to the Attention section.

SparsePR is a training-free sparse-attention method evaluated across four video generation and world models.